### PR TITLE
feat: member, teacher, student entity 구조 수정

### DIFF
--- a/app/src/main/kotlin/org/monsing/auth/AuthService.kt
+++ b/app/src/main/kotlin/org/monsing/auth/AuthService.kt
@@ -5,11 +5,9 @@ import org.monsing.auth.jwt.TokenPayload
 import org.monsing.auth.oauthhandler.OauthAdaptor
 import org.monsing.member.Member
 import org.monsing.member.MemberRepository
-import org.monsing.member.Nickname
 import org.monsing.member.OauthProviderType
 import org.monsing.token.Token
 import org.springframework.stereotype.Service
-import java.net.URL
 
 @Service
 class AuthService(
@@ -21,34 +19,7 @@ class AuthService(
     fun login(oauthProviderType: OauthProviderType, oauthToken: String): Token {
         val oauthIdentifier = oauthAdaptor.handle(oauthProviderType, oauthToken)
         val member = memberRepository.findByIdentifierAndOauthProviderType(oauthIdentifier.id, oauthProviderType)
-            ?: throw IllegalArgumentException("Member not found")
-
-        val id = requireNotNull(member.id) {
-            "Member id must not be null"
-        }
-
-        return Token(
-            accessToken = tokenManager.createAccessToken(TokenPayload(id)),
-            refreshToken = tokenManager.createRefreshToken(id)
-        )
-    }
-
-    fun register(registerDto: RegisterDto): Token {
-        val oauthIdentifier = oauthAdaptor.handle(
-            registerDto.oauthProviderType,
-            registerDto.oauthToken
-        )
-
-        val member = memberRepository.save(
-            Member(
-                identifier = oauthIdentifier.id,
-                oauthProviderType = registerDto.oauthProviderType,
-                memberType = registerDto.memberType,
-                nickname = Nickname(registerDto.nickname),
-                genderType = registerDto.genderType,
-                profileImage = URL(registerDto.profileImage)
-            )
-        )
+            ?: memberRepository.save(Member(oauthIdentifier.id, oauthProviderType))
 
         val id = requireNotNull(member.id) {
             "Member id must not be null"

--- a/app/src/main/kotlin/org/monsing/auth/RegisterDto.kt
+++ b/app/src/main/kotlin/org/monsing/auth/RegisterDto.kt
@@ -1,8 +1,7 @@
 package org.monsing.auth
 
-import org.monsing.member.GenderType
-import org.monsing.member.MemberType
 import org.monsing.member.OauthProviderType
+import org.monsing.member.teacher.GenderType
 
 data class RegisterDto(
     val nickname: String,
@@ -10,5 +9,4 @@ data class RegisterDto(
     val oauthProviderType: OauthProviderType,
     val genderType: GenderType,
     val profileImage: String,
-    val memberType: MemberType
 )

--- a/app/src/main/kotlin/org/monsing/auth/teacher/TeacherService.kt
+++ b/app/src/main/kotlin/org/monsing/auth/teacher/TeacherService.kt
@@ -1,6 +1,6 @@
 package org.monsing.auth.teacher
 
-import org.monsing.member.GenderType
+import org.monsing.member.teacher.GenderType
 import org.monsing.member.teacher.Teacher
 import org.monsing.member.teacher.TeacherRepository
 import org.springframework.data.repository.findByIdOrNull

--- a/domain/src/main/kotlin/org/monsing/member/Member.kt
+++ b/domain/src/main/kotlin/org/monsing/member/Member.kt
@@ -1,12 +1,7 @@
 package org.monsing.member
 
-import jakarta.persistence.Column
-import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
-import jakarta.persistence.EnumType
-import jakarta.persistence.Enumerated
 import org.monsing.BaseEntity
-import java.net.URL
 
 @Entity
 class Member(
@@ -14,16 +9,4 @@ class Member(
     val identifier: String,
 
     val oauthProviderType: OauthProviderType,
-
-    @Enumerated(EnumType.STRING)
-    val memberType: MemberType,
-
-    @Embedded
-    val nickname: Nickname,
-
-    @Enumerated(EnumType.STRING)
-    val genderType: GenderType,
-
-    @Column(name = "profile_image")
-    val profileImage: URL
 ) : BaseEntity()

--- a/domain/src/main/kotlin/org/monsing/member/MemberType.kt
+++ b/domain/src/main/kotlin/org/monsing/member/MemberType.kt
@@ -1,6 +1,0 @@
-package org.monsing.member
-
-enum class MemberType {
-    STUDENT,
-    TEACHER
-}

--- a/domain/src/main/kotlin/org/monsing/member/Student.kt
+++ b/domain/src/main/kotlin/org/monsing/member/Student.kt
@@ -1,11 +1,18 @@
 package org.monsing.member
 
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
-import jakarta.persistence.OneToOne
 import org.monsing.BaseEntity
 
 @Entity
 class Student(
-    @OneToOne
-    val member: Member
+
+    val memberId: Long,
+
+    @Column(name = "profile_image")
+    val profileImage: String? = null,
+
+    @Embedded
+    val nickname: Nickname,
 ) : BaseEntity()

--- a/domain/src/main/kotlin/org/monsing/member/teacher/GenderType.kt
+++ b/domain/src/main/kotlin/org/monsing/member/teacher/GenderType.kt
@@ -1,4 +1,4 @@
-package org.monsing.member
+package org.monsing.member.teacher
 
 enum class GenderType {
     MALE,

--- a/domain/src/main/kotlin/org/monsing/member/teacher/Teacher.kt
+++ b/domain/src/main/kotlin/org/monsing/member/teacher/Teacher.kt
@@ -1,20 +1,19 @@
 package org.monsing.member.teacher
 
+import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
-import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
-import jakarta.persistence.OneToOne
 import org.monsing.BaseEntity
-import org.monsing.member.Member
+import org.monsing.member.Nickname
 import org.monsing.member.StrongSideType
 
 @Entity
 class Teacher(
-    @OneToOne
-    @JoinColumn(name = "member_id")
-    val member: Member,
+
+    val memberId: Long,
 
     val summary: String,
 
@@ -27,10 +26,18 @@ class Teacher(
 
     val verified: Boolean,
 
+    @Embedded
+    val nickname: Nickname,
+
+    @Column(name = "profile_image")
+    val profileImage: String? = null,
+
+    @Enumerated(EnumType.STRING)
+    val genderType: GenderType,
+
     @OneToMany
     val portfolios: List<Portfolio> = mutableListOf(),
 
     @OneToMany
     val careers: List<Career> = mutableListOf()
-
 ) : BaseEntity()

--- a/domain/src/main/kotlin/org/monsing/member/teacher/TeacherCustomRepository.kt
+++ b/domain/src/main/kotlin/org/monsing/member/teacher/TeacherCustomRepository.kt
@@ -1,7 +1,5 @@
 package org.monsing.member.teacher
 
-import org.monsing.member.GenderType
-
 interface TeacherCustomRepository {
 
     fun findByConditions(

--- a/domain/src/main/kotlin/org/monsing/member/teacher/TeacherCustomRepositoryImpl.kt
+++ b/domain/src/main/kotlin/org/monsing/member/teacher/TeacherCustomRepositoryImpl.kt
@@ -6,8 +6,6 @@ import org.monsing.course.Price
 import org.monsing.eq
 import org.monsing.like
 import org.monsing.lt
-import org.monsing.member.GenderType
-import org.monsing.member.Member
 import org.monsing.member.Nickname
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.PageRequest
@@ -30,15 +28,13 @@ class TeacherCustomRepositoryImpl(
             select(entity(Teacher::class))
                 .from(
                     entity(Teacher::class),
-                    join(entity(Member::class))
-                        .on(path(Teacher::member).eq(entity(Member::class))),
                     join(entity(CourseTicket::class))
                         .on(entity(Teacher::class).eq(path(CourseTicket::teacher)))
                 )
                 .whereAnd(
-                    eq(path(Member::genderType), genderType),
+                    eq(path(Teacher::genderType), genderType),
                     eq(path(Teacher::verified), verified),
-                    like(path(Member::nickname)(Nickname::value), keyword),
+                    like(path(Teacher::nickname)(Nickname::value), keyword),
                     lt(path(CourseTicket::price)(Price::value), price),
                     path(Teacher::id).gt(lastId ?: 0L),
                 )


### PR DESCRIPTION
issue: #13 

member에 oauth 정보만 남김
member type 삭제

첫 로그인시 member로 저장되고 이후 온보딩을 마치면 student, teacher로 저장되는 flow